### PR TITLE
LXC 3.22 / LXD 3.22 Paths

### DIFF
--- a/telegraf-lxd-stats.go
+++ b/telegraf-lxd-stats.go
@@ -181,7 +181,7 @@ func readCgroupFile(task CgroupTask, channel chan<- CgroupTaskResult) {
 
 func genCgroupTaskList(lxdList []string) []CgroupTask {
 	tasks := make([]CgroupTask, 0)
-	for _, lxc_dir := range [...]string{"lxc", "lxc.monitoring", "lxc.payload"} {
+	for _, lxc_dir := range [...]string{"lxc", "lxc.monitor", "lxc.payload"} {
 		for _, lxd := range lxdList {
 			var t CgroupTask
 			t.cgroupItem = "blkio.throttle.io_serviced"


### PR DESCRIPTION
In Ubuntu 20.04 with LXC 3.22 / LXD 3.22, the paths don't have monitoring but monitor in the path